### PR TITLE
Improve caching performance & fix error output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
 .vscode
-/cache
+/.cache
 node_modules
 package-lock.json
 yarn.lock

--- a/src/Powercord/modules/jsx.js
+++ b/src/Powercord/modules/jsx.js
@@ -18,16 +18,18 @@
 
 const sucrase = require('sucrase');
 const { join } = require('path');
-const { readFileSync, mkdirSync, statSync, writeFile } = require('fs');
+const { readFileSync, mkdirSync, existsSync, statSync, writeFile } = require('fs');
 const { createHash } = require('crypto');
 
-const cacheDir = join(__dirname, '../../../cache/jsx/');
+const cacheDir = join(__dirname, '../../../.cache');
+
+if (!existsSync(cacheDir)) {
+  mkdirSync(cacheDir);
+}
 
 const checksum = (str) => createHash('sha1').update(str).digest('hex');
 
 module.exports = () => {
-  mkdirSync(cacheDir, { recursive: true });
-
   require.extensions['.jsx'] = (_module, filename) => {
     const stat = statSync(filename);
     const hash = checksum(filename + stat.mtime.toISOString());

--- a/src/Powercord/modules/jsx.js
+++ b/src/Powercord/modules/jsx.js
@@ -47,11 +47,9 @@ module.exports = () => {
 
       writeFile(cached, res, (err) => {
         if (!err) {
-          return;
+          console.error('[JSX]', 'Failed to write to cache');
+          console.error(err);
         }
-
-        console.error('[JSX]', 'Failed to write to cache');
-        console.error(err);
       });
     }
   };


### PR DESCRIPTION
Improved performance by preemptively creating the cache directory when the "modules" module itself is required instead of rechecking every time a jsx file is loaded. Also flattened the directory and renamed it to `.cache` in order to emphasize it's not part of the project files.

The writeback into the cache was returning on error and attempting to log the error afterwards, I fixed it by moving the log calls up into the if.

Maybe there should be a command to clean the cache? Dunno if it should be added to the injector, created as a separate script or simply solved by depending on rimraf, del etc.

EDIT: typos & clarification